### PR TITLE
Add mock data for CFR changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 Glue project which combines regulations-site, regulations-core and
 styles/templates for Notice and Comment. Packaged as a cloud.gov app.
 
+## Important URLs
+
+* `/preamble/2016_02749/I` - the first section of the preamble associated with
+  an recent EPA proposal
+* `/preamble/2016_02749/cfr_changes/478` - the "authorities" for this CFR part
+* `/preamble/2016_02749/cfr_changes/478-32` - the diff view for a specific
+  section
+
 ## Local Development
 Like regulations-site and regulations-core, this application requires Python 2.7.
 

--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 
@@ -28,3 +29,57 @@ ATTACHMENT_BUCKET = os.environ.get('S3_BUCKET')
 REGS_GOV_API_URL = os.environ.get('REGS_GOV_API_URL')
 REGS_GOV_API_LOOKUP_URL = os.environ.get('REGS_GOV_API_LOOKUP_URL')
 REGS_GOV_API_KEY = os.environ.get('REGS_GOV_API_KEY')
+
+CFR_CHANGES = {
+    "2016_02749": {
+        "versions": {
+            "478": {"left": "2010-13392", "right": "2012-13762"}
+        },
+        "amendments": [
+            {"instruction": """
+                1. The authority citation for 27 CFR part 478 is revised to
+                read as follows:""",
+             "cfr_part": "478",
+             "authority":
+                '5 U.S.C. 552(a); 18 U.S.C. 847, 921-931; 44 U.S.C. 3504(h).'},
+            {"instruction": u"""
+                2. Section 478.11 is amended by adding a definition for the
+                term “Nonimmigrant visa” in alphabetical order to read as
+                follows:""",
+             "cfr_part": "478",
+             "changes": {"478-11-p242755046": []}},
+            {"instruction": """
+                3. Section 478.32 is amended by revising the introductory text
+                of paragraphs (a)(5)(ii) and (d)(5)(ii), and by revising
+                paragraph (f), to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-32-a-5-ii": [], "478-32-d-5-ii": [],
+                         "478-32-f": []}},
+            {"instruction": """
+                4. Section 478.44 is amended by revising paragraph
+                (a)(1)(iii), and by revising the second sentence in paragraph
+                (b), to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-44-a-1-iii": [], "478-44-b": []}},
+            {"instruction": """
+                5. Section 478.45 is amended by revising the second sentence
+                to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-45": []}},
+            {"instruction": """
+                6. Section 478.99 is amended by revising the introductory text
+                of paragraph (c)(5) to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-99-c-5": []}},
+            {"instruction": """
+                7. Section 478.120 is revised to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-120": []}},
+            {"instruction": """
+                8. Section 478.124 is amended by revising paragraph
+                (c)(3)(iii) to read as follows:""",
+             "cfr_part": "478",
+             "changes": {"478-124-c-3-iii": []}}
+        ]
+    }
+}


### PR DESCRIPTION
While we work on generating this data automatically, provide some mock data
related to 27 CFR 478 @ 2012-13762. Note that the structure has "empty"
changes -- turns out that information isn't relevant here, though we want it
in the parser.

Part of #89