### PR TITLE
fixes #97 changing font weight and width of tabs

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -20,6 +20,10 @@
   .read-proposal,
   .write-comment {
 
+    .font-bold;
+    height: 33px;
+    width: 225px;
+
     .read-icon,
     .write-icon {
       fill: @dark_text;

--- a/notice_and_comment/static/regulations/css/less/module/header-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/header-custom.less
@@ -9,6 +9,7 @@
 
 .sub-head {
   top: 3.5em;
+  background: @light_gray;
 }
 
 /*


### PR DESCRIPTION
![screen shot 2016-04-05 at 4 59 55 pm](https://cloud.githubusercontent.com/assets/776987/14299403/d996ac10-fb4f-11e5-90f9-52e122fbebcc.png)

This changes the font weight on the tabs, the extra pixel on the tab borders, and the color on the sub-header mentioned in #97 