### PR TITLE
adding custom read/write mode tabs

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -23,18 +23,33 @@
     .font-bold;
     height: 33px;
     width: 225px;
+    transition: 0.1s;
 
     .read-icon,
     .write-icon {
-      fill: @dark_text;
+      fill: @navigation_gray;
     }
 
     span {
       padding-left: 5px;
     }
+
+    &:hover:not(.active-mode) {
+      background: @white;
+      color: @blue;
+      height: 32px;
+
+      .read-icon,
+      .write-icon {
+        fill: @blue;
+      }
+    }
   }
 
   .active-mode {
+
+    background: @white;
+    color: @blue;
 
     .read-icon,
     .write-icon {


### PR DESCRIPTION
adds hover styles to read/write mode tabs

Is that double selector thing I did on Line#37 ok? It's to ensure the active tab doesn't get re-styled when hovered.

![imd8wehlfr](https://cloud.githubusercontent.com/assets/776987/14444620/42d8dcdc-000c-11e6-9d54-2e8136496075.gif)
