### PR TITLE
Fix GNU-style command-line options

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -16,4 +16,4 @@ applications:
     no-route: true
     command: >
       python manage.py fetch_wkhtmltox &&
-      celery worker --app notice_and_comment -loglevel DEBUG
+      celery worker --app=notice_and_comment --loglevel=DEBUG


### PR DESCRIPTION
Celery only supports --option=value and not --option value or -option
value