### PR TITLE
adding n&C colors for paragraph commenting

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -2,7 +2,15 @@
   color: @link_blue_inactive;
 
   &:hover {
-    color: @link_blue;
+    color: @blue;
+
+    .comment-icon {
+      fill: @blue;
+    }
+  }
+
+  .comment-icon {
+    fill: @link_blue_inactive;
   }
 }
 


### PR DESCRIPTION
adds the N&C specific colors to the piece added in eregs/regulations-site#226

fixes #60 

![screen shot 2016-04-12 at 5 04 54 pm](https://cloud.githubusercontent.com/assets/776987/14477241/25972dec-00d2-11e6-945b-938b8a3cc038.png)
