### PR TITLE
Configure celery to ack tasks on complete.

### DIFF
--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -22,12 +22,13 @@ STATICFILES_DIRS = ['compiled']
 
 # Commenting
 BROKER_URL = 'redis://localhost:6379/0'
+CELERY_ACKS_LATE = True
 
 CACHES['regs_gov_cache'] = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': BROKER_URL,
     'KEY_PREFIX': 'regs.gov',
-    'TIMEOUT': 60*60*24,
+    'TIMEOUT': 60 * 60 * 24,
     'OPTIONS': {
         'IGNORE_EXCEPTIONS': True,
     }


### PR DESCRIPTION
As discussed in #30, this configuration ensures that tasks aren't
considered finished in the event that a worker crashes or loses its
connection to the broker. In exchange for this behavior, we run a small
risk of duplicate submits.

[Resolves #30]