### PR TITLE
Footnotes design styles

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/custom.less
@@ -13,3 +13,4 @@
 @import "drawer-content-custom.less";
 @import "drawer-custom.less";
 @import "header-custom.less";
+@import "note-custom.less";

--- a/notice_and_comment/static/regulations/css/less/module/note-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/note-custom.less
@@ -1,0 +1,23 @@
+// N&C specific Footnotes
+
+.footnote-box {
+  background-color: none;
+  padding: 1.5em 0 0 0;
+
+  h5 {
+    color: @dark_text;
+    margin-top: 0;
+  }
+
+  .footnotes {
+    li {
+      border-top: 2px solid @gray;
+      padding: 1em 0 0 1em;
+
+      p {
+        margin-left: 1em;
+        padding-right: 2em;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Per #52, N&C footnotes to match CFPB style.

<img width="1142" alt="screen shot 2016-04-18 at 11 22 09 am" src="https://cloud.githubusercontent.com/assets/24054/14614849/d21394fa-0557-11e6-857e-970a286797db.png">
