### PR TITLE
Footnotes - jump back links

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/note-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/note-custom.less
@@ -1,4 +1,8 @@
-// N&C specific Footnotes
+/*
+ Custom Footnotes
+ ==========================================================================
+ note-custom.less defines CFPB style footnotes for Notice & Comment
+ */
 
 .footnote-box {
   background-color: none;
@@ -13,11 +17,27 @@
     li {
       border-top: 2px solid @gray;
       padding: 1em 0 0 1em;
+      position: relative;
 
       p {
         margin-left: 1em;
-        padding-right: 2em;
+        width: 90%;
+      }
+
+      .cf-icon {
+        position: absolute;
+        right: 10px;
+        top: 50%;
       }
     }
   }
+}
+
+// get footnote jump back links to position past fixed header
+.footnote-jump-link:before {
+  content: "";
+  display: inline-block;
+  height: 100px;
+  margin: -100px 0 0;
+  visibility: hidden;
 }

--- a/notice_and_comment/templates/regulations/footnotes.html
+++ b/notice_and_comment/templates/regulations/footnotes.html
@@ -1,0 +1,18 @@
+  {% if sub_context.node.footnotes %}
+  <div class="footnote-box">
+    <h5>Footnotes</h5>
+    <ul class="footnotes">
+      {% for footnote in sub_context.node.footnotes %}
+      <li id="footnote-{{ footnote.ref }}">
+        <span class="reference-num">{{ footnote.ref }}.</span>
+        <p>
+          {{ footnote.note }}
+        </p>
+        <a href="#footnote-jump-{{ footnote.ref }}">
+          <span class="cf-icon cf-icon-up-round"></span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}


### PR DESCRIPTION
Clicking the up arrow icon on footnotes will take the user back to the section they were on. #52

<img width="1164" alt="screen shot 2016-04-19 at 10 33 58 am" src="https://cloud.githubusercontent.com/assets/24054/14649116/845cd8f2-061a-11e6-83b0-1dfb6d76c3e4.png">
