### PR TITLE
Add middleware for basic auth requirement

### DIFF
--- a/notice_and_comment/basic_auth.py
+++ b/notice_and_comment/basic_auth.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+
+from regcore_write.views.security import basic_auth
+
+
+class BasicAuthMiddleware(object):
+    """Wrap all requests in the same basic auth we're using in regcore"""
+    def process_request(self, request):
+        if settings.HTTP_AUTH_USER and settings.HTTP_AUTH_PASSWORD:
+            # "None" means success; basic_auth is a decorator
+            thunk = basic_auth(lambda req: None)
+            return thunk(request)

--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -15,8 +15,12 @@ ROOT_URLCONF = 'notice_and_comment.urls'
 
 DATABASES = REGCORE_DATABASES
 
-API_BASE = 'http://localhost:{}/api/'.format(
-    os.environ.get('VCAP_APP_PORT', '8000'))
+_port = os.environ.get('VCAP_APP_PORT', '8000')
+if HTTP_AUTH_USER and HTTP_AUTH_PASSWORD:
+    API_BASE = 'http://{}:{}@localhost:{}/api/'.format(
+        HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, _port)
+else:
+    API_BASE = 'http://localhost:{}/api/'.format(_port)
 
 STATICFILES_DIRS = ['compiled']
 
@@ -192,4 +196,14 @@ WKHTMLTOPDF_PATH = os.getenv(
         os.path.dirname(__file__), '..', '..',
         'wkhtmltox', 'bin', 'wkhtmltopdf',
     ),
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
+    'notice_and_comment.basic_auth.BasicAuthMiddleware'
 )

--- a/notice_and_comment/settings/prod.py
+++ b/notice_and_comment/settings/prod.py
@@ -50,3 +50,9 @@ REGS_GOV_API_KEY = env.get_credential(
     'REGS_GOV_API_KEY', os.environ.get('REGS_GOV_API_KEY'))
 HTTP_AUTH_USER = env.get_credential('HTTP_AUTH_USER')
 HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
+
+# HTTP Auth may have be different due to the above lines
+if HTTP_AUTH_USER and HTTP_AUTH_PASSWORD:
+    API_BASE = 'http://{}:{}@localhost:{}/api/'.format(
+        HTTP_AUTH_USER, HTTP_AUTH_PASSWORD,
+        os.environ.get('VCAP_APP_PORT', '8000'))


### PR DESCRIPTION
Reuses the existing, relatively hardened HTTP AUTH comparisons from regcore.
Due to the loop back, we need to also set the AUTH info in API_BASE

Resolves #240.

I can imagine agencies wanting to add auth to only certain paths, but I don't think we need that flexibility in the near future.

Note, this will require everyone using the demo site (even just for data retrieval) add appropriate authentication. Please flag our dev channel before merging.