### PR TITLE
adding color overrides for some parts of the toc drawer

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
@@ -88,6 +88,6 @@ currently these are TOC, History, and Search
         }
     }
     .panel-slide {
-      border-bottom: 1px solid @dark_gray;
+      border-bottom: none;
     }
 }

--- a/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
@@ -11,25 +11,27 @@ Universal drawer styles
 --------------------- */
 
 .panel {
-    background-color: @light_gray;
-    border-right: 2px solid @dark_gray;
-    .font-regular;
-    font-size: 1em;
-    overflow-y: scroll; /* allow content to be scrollable */
+  background-color: @light_gray;
+  border-right: 2px solid @dark_gray;
+  .font-regular;
+  font-size: 1em;
+  overflow-y: scroll; /* allow content to be scrollable */
 }
 
 .toc-head {
-    a:link,
-    a:visited {
-      color: @navigation_gray;
-    }
+  border-right: 2px solid @dark_gray;
 
-    a:hover,
-    a:active,
-    a.current {
-        background-color: @white;
-        color: @blue;
-    }
+  a:link,
+  a:visited {
+    color: @navigation_gray;
+  }
+
+  a:hover,
+  a:active,
+  a.current {
+      background-color: @white;
+      color: @blue;
+  }
 }
 
 /*
@@ -84,5 +86,8 @@ currently these are TOC, History, and Search
         &.current {
             background-color: @white;
         }
+    }
+    .panel-slide {
+      border-bottom: 1px solid @dark_gray;
     }
 }


### PR DESCRIPTION
There were a few pieces of the ToC drawer that didn't receive color overrides and looked out of place when the drawer was collapsed. 

![screen shot 2016-04-29 at 11 09 24 am](https://cloud.githubusercontent.com/assets/776987/14922022/df275388-0dfa-11e6-81d4-4be6cc7e1026.png)
![screen shot 2016-04-29 at 11 09 16 am](https://cloud.githubusercontent.com/assets/776987/14922023/df27e78a-0dfa-11e6-9a82-12b389ffd483.png)
