### PR TITLE
Use file-based cache for regs.gov lookups

### DIFF
--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -29,8 +29,8 @@ BROKER_URL = 'redis://localhost:6379/0'
 CELERY_ACKS_LATE = True
 
 CACHES['regs_gov_cache'] = {
-    'BACKEND': 'django_redis.cache.RedisCache',
-    'LOCATION': BROKER_URL,
+    'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+    'LOCATION': '/tmp/regs_gov_cache',
     'KEY_PREFIX': 'regs.gov',
     'TIMEOUT': 60 * 60 * 24,
     'OPTIONS': {

--- a/notice_and_comment/settings/prod.py
+++ b/notice_and_comment/settings/prod.py
@@ -35,6 +35,8 @@ if redis:
     url = redis.get_url(host='hostname', password='password', port='port')
     BROKER_URL = 'redis://{}'.format(url)
     CACHES['regs_gov_cache']['LOCATION'] = BROKER_URL
+    CACHES['regs_gov_cache']['BACKEND'] = 'django_redis.cache.RedisCache'
+
 
 s3 = env.get_service(label='s3')
 if s3:


### PR DESCRIPTION
- Use a file-based cache in dev environment
- Use redis in the prod environment