### PR TITLE
Fix read/write tab colors

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -24,6 +24,14 @@
     width: 225px;
     transition: 0.1s;
 
+    a {
+      color: @navigation_gray;
+    }
+
+    &.active-mode a {
+      color: @blue;
+    }
+
     .read-icon,
     .write-icon {
       fill: @navigation_gray;
@@ -41,7 +49,6 @@
   }
 
   .active-mode {
-
     background: @white;
     color: @blue;
 

--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -51,6 +51,10 @@
     .write-icon {
       fill: @blue;
     }
+
+    a {
+      padding-left: 5px;
+    }
   }
 }
 

--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -26,6 +26,7 @@
 
     a {
       color: @navigation_gray;
+      padding-left: 5px;
     }
 
     &.active-mode a {
@@ -54,10 +55,6 @@
     .read-icon,
     .write-icon {
       fill: @blue;
-    }
-
-    a {
-      padding-left: 5px;
     }
   }
 }

--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -37,14 +37,9 @@
       fill: @navigation_gray;
     }
 
-    &:hover:not(.active-mode) {
-      background: @white;
+    &:hover span,
+    &:hover a {
       color: @blue;
-
-      .read-icon,
-      .write-icon {
-        fill: @blue;
-      }
     }
   }
 

--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -41,6 +41,10 @@
     &:hover a {
       color: @blue;
     }
+
+    &:hover:not(.active-mode) {
+      background: lighten(@gray, 10%);
+    }
   }
 
   .active-mode {


### PR DESCRIPTION
Make sure Read and Write tab colors are correct, per #256

<img width="518" alt="screen shot 2016-05-09 at 12 50 02 pm" src="https://cloud.githubusercontent.com/assets/24054/15120656/bf63c404-15e4-11e6-8197-ccc03a771379.png">

When hovering over Write tab:
<img width="512" alt="screen shot 2016-05-09 at 12 55 31 pm" src="https://cloud.githubusercontent.com/assets/24054/15120817/78c80d42-15e5-11e6-8ed6-c7e7422e7516.png">
