### PR TITLE
Restore celery import.

### DIFF
--- a/notice_and_comment/__init__.py
+++ b/notice_and_comment/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .celery import app as celery_app  # noqa


### PR DESCRIPTION
Turns out this import is needed for the django app to pick up the celery
configuration.