### PR TITLE
Footnote fixes

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/note-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/note-custom.less
@@ -19,9 +19,16 @@
       padding: 1em 0 0 1em;
       position: relative;
 
+      // positioning for jump links
+      // the :before hack doesn't work here for some reason
+      .footnote-content {
+        padding-top: 100px;
+        margin-top: -100px;
+        width: 90%;
+      }
+
       p {
         margin-left: 1em;
-        width: 90%;
       }
 
       .cf-icon {

--- a/notice_and_comment/static/regulations/css/less/module/note-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/note-custom.less
@@ -33,11 +33,18 @@
   }
 }
 
-// get footnote jump back links to position past fixed header
-.footnote-jump-link:before {
-  content: "";
-  display: inline-block;
-  height: 100px;
-  margin: -100px 0 0;
-  visibility: hidden;
+.footnote-jump-link {
+
+  &:link {
+    outline: none;
+  }
+
+  &:before {
+    // get footnote jump back links to position past fixed header
+    content: "";
+    display: inline-block;
+    height: 100px;
+    margin: -100px 0 0;
+    visibility: hidden;
+  }
 }

--- a/notice_and_comment/templates/regulations/footnotes.html
+++ b/notice_and_comment/templates/regulations/footnotes.html
@@ -3,14 +3,16 @@
     <h5>Footnotes</h5>
     <ul class="footnotes">
       {% for footnote in sub_context.node.footnotes %}
-      <li id="footnote-{{ footnote.ref }}">
-        <span class="reference-num">{{ footnote.ref }}.</span>
-        <p>
-          {{ footnote.note }}
-        </p>
-        <a href="#footnote-jump-{{ footnote.ref }}">
-          <span class="cf-icon cf-icon-up-round"></span>
-        </a>
+      <li>
+        <div id="footnote-{{ footnote.ref }}" class="footnote-content">
+          <span class="reference-num">{{ footnote.ref }}.</span>
+          <p>
+            {{ footnote.note }}
+          </p>
+          <a href="#footnote-jump-{{ footnote.ref }}">
+            <span class="cf-icon cf-icon-up-round"></span>
+          </a>
+        </div>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
* Remove outline on jump links to fix #181 
* Positioning hack for more accurate anchor positioning #180 