### PR TITLE
Homepage hero positioning

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -25,8 +25,9 @@
   .hero {
     background-color: unset;
     background-image: url(../../regulations/img/homepage-hero.jpg);
+    background-position: top center;
     background-repeat: no-repeat;
-    background-size: contain;
+    background-size: cover;
     border-bottom: none;
     overflow: auto;
     padding: 30px 0 0 0;


### PR DESCRIPTION
Update positioning of hero image on homepage so that it is always centered, addresses #268:

<img width="1116" alt="screen shot 2016-05-10 at 9 57 18 pm" src="https://cloud.githubusercontent.com/assets/24054/15170401/3c8ad204-16fa-11e6-8a34-7222dc3283bb.png">
