### PR TITLE
Homepage style tweaks

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -226,6 +226,7 @@ Read and write with ease
       }
 
       .collapsible {
+        .font-regular;
         margin: 25px 15px;
 
         ul {

--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -326,6 +326,10 @@ About this tool
 */
   .about-this-tool {
 
+    h2 {
+      margin-bottom: 1.2em;
+    }
+
     .about-this-tool-content {
       display: -webkit-flex;
       display: flex;


### PR DESCRIPTION
- "Other ways to read and comment" collapsible section should have regular font:
<img width="687" alt="screen shot 2016-05-16 at 12 15 59 pm" src="https://cloud.githubusercontent.com/assets/24054/15300947/21a554c2-1b60-11e6-951a-93562e41f9f9.png">
- More padding under "About this tool" header
<img width="861" alt="screen shot 2016-05-16 at 12 16 03 pm" src="https://cloud.githubusercontent.com/assets/24054/15300957/29aad584-1b60-11e6-86d6-4cbd66e9282a.png">
