### PR TITLE
new blues everywhere

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -15,6 +15,36 @@
   }
 }
 
+.comment-button,
+a.comment-index-review {
+  background-color: @blue;
+  border-radius: 2px;
+  color: @white;
+
+  &:hover {
+    background-color: darken(@blue, 10%);
+  }
+}
+
+.comment-header {
+  & > a {
+    color: @black;
+    border-bottom: 2px solid @link_blue;
+  }
+}
+
+.comment-index {
+
+  li {
+    background: @gray;
+    color: @black;
+
+    &:hover {
+      background: lighten(@gray, 10%);;
+    }
+  }
+}
+
 .preamble-header {
 
   .read-proposal,
@@ -59,30 +89,6 @@
   }
 }
 
-
-.comment-button,
-a.comment-index-review {
-  background-color: @blue;
-  border-radius: 2px;
-  color: @white;
-
-  &:hover {
-    background-color: darken(@blue, 10%);
-  }
-}
-
-.comment-index {
-
-  li {
-    background: @gray;
-    color: @black;
-
-    &:hover {
-      background: lighten(@gray, 10%);;
-    }
-  }
-}
-
 #preamble-read {
   .cfr-instructions {
     font-family: "Merriweather", Georgia, serif;
@@ -91,6 +97,21 @@ a.comment-index-review {
 
   .show-more-context {
     background-color: @light_gray;
-    color: @blue;
+    color: @link_blue;
+  }
+}
+
+
+#comment-review {
+  .statement {
+    .show-more-toggle {
+      display: inline;
+      color: @link_blue;
+      font-size: 14px;
+
+      &:hover {
+        color: darken(@link_blue, 10%);
+      }
+    }
   }
 }

--- a/notice_and_comment/static/regulations/css/less/module/custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/custom.less
@@ -12,6 +12,7 @@
 
 @import "drawer-content-custom.less";
 @import "drawer-custom.less";
+@import "footer-custom.less";
 @import "header-custom.less";
 @import "note-custom.less";
 @import "nc-homepage-custom.less";

--- a/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/drawer-custom.less
@@ -30,7 +30,7 @@ Universal drawer styles
   a:active,
   a.current {
       background-color: @white;
-      color: @blue;
+      color: @link_blue;
   }
 }
 

--- a/notice_and_comment/static/regulations/css/less/module/footer-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/footer-custom.less
@@ -1,0 +1,4 @@
+.next-prev-link:link,
+.next-prev-link:visited {
+    color: @link_blue;
+}

--- a/notice_and_comment/static/regulations/css/less/typography-custom.less
+++ b/notice_and_comment/static/regulations/css/less/typography-custom.less
@@ -4,6 +4,11 @@
  typography-custom.less defines font face and styles specific to Notice & Comment
  */
 
+ a:link,
+ a:visited {
+     color: @link_blue;
+ }
+
 h1,
 h2,
 h3,

--- a/notice_and_comment/static/regulations/css/less/variables.less
+++ b/notice_and_comment/static/regulations/css/less/variables.less
@@ -11,7 +11,7 @@ variables.less contains all theme variable / variable overrides
 @black: #212121;
 @white: #ffffff;
 
-@blue: #0071BC;
+@blue: #205493;
 @light_blue: #A1CBFC;
 @dark_blue: #1F5593;
 @aqua_blue: #B3E0EB;


### PR DESCRIPTION
fixes #159 

This is mostly just changing the `@blue` variable and then making some things that were using it incorrectly use the `@link_blue`

The header and tabs are now "mature blue"

![screen shot 2016-05-17 at 3 00 05 pm](https://cloud.githubusercontent.com/assets/776987/15338568/2353ec48-1c46-11e6-87eb-05d1a8b772fb.png)
