### PR TITLE
WIP - updating type hierarchy

### DIFF
--- a/notice_and_comment/static/regulations/css/less/typography-custom.less
+++ b/notice_and_comment/static/regulations/css/less/typography-custom.less
@@ -46,6 +46,7 @@ h4 {
 h5 {
   font-size: 19px;
   line-height: 24px;
+  text-transform: uppercase;
 }
 
 h6 {

--- a/notice_and_comment/static/regulations/css/less/typography-custom.less
+++ b/notice_and_comment/static/regulations/css/less/typography-custom.less
@@ -27,20 +27,26 @@ h1 {
     line-height: 50px;
 }
 
-h2, h3.section-title {
-    font-size: 34px;
-    line-height: 40px;
-    margin: 20px 0;
+h2 {
+  font-family: 'Source Sans Pro', Georgia, sans-serif;
+  font-weight: 300;
+  font-size: 44px;
+  line-height: 50px;
 }
 
 h3 {
-    font-size: 24px;
-    line-height: 29px;
+  font-size: 34px;
+  line-height: 40px;
 }
 
-h4, h5 {
-    font-size: 19px;
-    line-height: 24px;
+h4 {
+  font-size: 24px;
+  line-height: 29px;
+}
+
+h5 {
+  font-size: 19px;
+  line-height: 24px;
 }
 
 h6 {

--- a/notice_and_comment/static/regulations/css/less/typography-custom.less
+++ b/notice_and_comment/static/regulations/css/less/typography-custom.less
@@ -21,14 +21,12 @@ h6 {
 }
 
 h1 {
-    font-family: 'Source Sans Pro', Georgia, sans-serif;
-    font-weight: 300;
-    font-size: 44px;
-    line-height: 50px;
+  font-weight: 300;
+  font-size: 44px;
+  line-height: 50px;
 }
 
 h2 {
-  font-family: 'Source Sans Pro', Georgia, sans-serif;
   font-weight: 300;
   font-size: 44px;
   line-height: 50px;
@@ -42,6 +40,7 @@ h3 {
 h4 {
   font-size: 24px;
   line-height: 29px;
+  text-transform: none;
 }
 
 h5 {


### PR DESCRIPTION
This updates the type hierarchy for N&C. 

There was a rule that was manually styling h3's that were `section-title`s but now that everything got shifted, I don't think it's needed anymore. There will be another PR In -site that will turn a bunch of `h3` into `h4` on some of the new sections we wrote (comment review, comment composition page) but it seems like these styles work appropriately for the algorithmically generated paragraphs/headers in the preamble.

This isn't playing nice with old eregs but wanted to get the PR up so other people could clone it. 