### PR TITLE
Fetch wkhtmltox from within travis

### DIFF
--- a/deploy-travis.sh
+++ b/deploy-travis.sh
@@ -1,4 +1,6 @@
 set -e
 
 cd $TRAVIS_BUILD_DIR
+# Fetch this binary within travis rather than within cloud.gov
+python manage.py fetch_wkhtmltox
 ./deploy.sh dev


### PR DESCRIPTION
This reduces the likelihood that deploy will timeout as less time is spent
within cloud.gov

For #339 

There's a soft dependency on eregs/regulations-site#379 ; merging this first won't break anything, it just won't be useful.