### PR TITLE
Avoid defining a new variable

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/drawer-content-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/drawer-content-custom.less
@@ -15,6 +15,5 @@ This contains all of the styles specific to the TOC
     a:active,
     .current {
         color: @black;
-        background-color: @navigation_light_blue;
     }
 }

--- a/notice_and_comment/static/regulations/css/less/variables.less
+++ b/notice_and_comment/static/regulations/css/less/variables.less
@@ -22,7 +22,7 @@ variables.less contains all theme variable / variable overrides
 
 @gray_blue: #5B616B;
 @navigation_gray: #676767;
-@navigation_light_blue: #E1F3F8;
+@toc_highlight: #E1F3F8;
 
 @light_gray: #F5F5F5;
 @gray: #D6D7D9;


### PR DESCRIPTION
A semantically-named variable is now present in -site. Rather than making a
new variable in n&c, reuse that one.

Relies on eregs/regulations-site#382