### PR TITLE
Fix homepage image

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -24,7 +24,6 @@
     height: 394px;
     position: absolute;
     right: 0;
-    z-index: -1;
   }
 
   h1 {
@@ -41,10 +40,11 @@
   }
 
   .hero {
-    background-color: unset;
+    background-color: transparent;
     border-bottom: none;
     overflow: auto;
     padding: 50px 0 0 0;
+    position: relative;
     width: 100%;
   }
 


### PR DESCRIPTION
Remove negative z-index, more accurate positioning, and transparent background on `.hero` so the background hero image displays properly on environments like IE11.

Fixes #335 

<img width="981" alt="screen shot 2016-06-02 at 5 22 25 pm" src="https://cloud.githubusercontent.com/assets/24054/15765228/ecf0576a-28e6-11e6-8084-40fcbfdd85e7.png">
