### PR TITLE
Set anchor tags for accessible tab navigation

### DIFF
--- a/notice_and_comment/templates/regulations/comment-additional-info.html
+++ b/notice_and_comment/templates/regulations/comment-additional-info.html
@@ -3,10 +3,10 @@
 
   <div class="comment-form-fieldlabel">I'm submitting on behalf of...</div>
 
-  <div class="tabs btn-group" role"group">
-    <div data-tab-set="commenter" data-tab="self" class="btn-group-item">Myself</div>
-    <div data-tab-set="commenter" data-tab="organization" class="btn-group-item">An Organization</div>
-    <div data-tab-set="commenter" data-tab="agency" class="btn-group-item">A Government Agency</div>
+  <div id="comment-btn-group" class="tabs btn-group" role"group">
+    <a data-tab-set="commenter" data-tab="self" class="btn-group-item" href="#">Myself</a>
+    <a data-tab-set="commenter" data-tab="organization" class="btn-group-item" href="#">An Organization</a>
+    <a data-tab-set="commenter" data-tab="agency" class="btn-group-item" href="#">A Government Agency</a>
   </div>
 
   <fieldset>

--- a/notice_and_comment/templates/regulations/comment-disclaimer.html
+++ b/notice_and_comment/templates/regulations/comment-disclaimer.html
@@ -1,4 +1,4 @@
-<div>
+<div class="comment-disclaimer">
   <ul class="statement-list">
     <li class="toggle">
       <h6>You are filing a document into an official docket.</h6>
@@ -14,14 +14,14 @@
           government computer system.
         </p>
       </div>
-      <span class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-0">
+      <a class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-0" href="#collapsible-0">
         <span class="toggle-button-open" aria-hidden="false">
           <span class="fa fa-plus-circle text-expand"></span>Show more
         </span>
         <span class="toggle-button-close" aria-hidden="false">
           <span class="fa fa-minus-circle text-expand"></span>Show less
         </span>
-      </span>
+      </a>
     </li>
     <li class="toggle">
       <h6>Any information entered on this form may be publicly viewable on the web.</h6>
@@ -49,14 +49,14 @@
           section of the Federal Register notice.
         </p>
       </div>
-      <span class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-1">
+      <a class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-1" href="#collapsible-1">
         <span class="toggle-button-open" aria-hidden="false">
           <span class="fa fa-plus-circle text-expand"></span>Show more
         </span>
         <span class="toggle-button-close" aria-hidden="false">
           <span class="fa fa-minus-circle text-expand"></span>Show less
         </span>
-      </span>
+      </a>
     </li>
     <li class="toggle">
       <h6>EPA is considered the official custodian of the comment, not this website.</h6>
@@ -68,14 +68,14 @@
           of the Federal Register, which is available online via the FederalRegister.gov website.
         </p>
       </div>
-      <span class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-2">
+      <a class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-2" href="#collapsible-2">
         <span class="toggle-button-open" aria-hidden="false">
           <span class="fa fa-plus-circle text-expand"></span>Show more
         </span>
-        <span class="toggle-button-close" aria-hidden="true">
+        <span class="toggle-button-close" aria-hidden="false">
           <span class="fa fa-minus-circle text-expand"></span>Show less
         </span>
-      </span>
+      </a>
     </li>
     <li class="toggle">
       <h6>
@@ -93,14 +93,14 @@
           in accordance with the requirements described in the Federal Register notice.
         </p>
       </div>
-      <span class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-3">
+      <a class="show-more-toggle button" aria-expanded="false" aria-controls="collapsible-3" href="#collapsible-3">
         <span class="toggle-button-open" aria-hidden="false">
           <span class="fa fa-plus-circle text-expand"></span>Show more
         </span>
         <span class="toggle-button-close" aria-hidden="false">
           <span class="fa fa-minus-circle text-expand"></span>Show less
         </span>
-      </span>
+      </a>
     </li>
   </ul>
 


### PR DESCRIPTION
Review your full comment:
- Comment additional info tabs (submitting on behalf of) now tab accessible
- Comment disclaimer show more/less toggles now tab accessible

Relies on: eregs/regulations-site#393