### PR TITLE
Avoid auto-collectstaticing when deploying

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -9,6 +9,7 @@ services:
   - eregsnc-creds
 env:
   DJANGO_SETTINGS_MODULE: notice_and_comment.settings.prod
+  DISABLE_COLLECTSTATIC: 1
 applications:
   - name: eregs-web
   - name: eregs-worker


### PR DESCRIPTION
The cloud.gov Python buildpack attempts to `collectstatic` before all of the
environmental variables are set up (at least, that's how I'm interpreting a
deploy error). We used to default to `/tmp/static` or similar, but recently
removed that, which has negative security implications. As such, the
`collectstatic` issue is biting us.

This sets an environment variable which tells the buildpack to avoid
`collectstatic`ing -- we do it later in the deployment, anyway.