### PR TITLE
Homepage Mobile Polish

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/custom.less
@@ -16,3 +16,4 @@
 @import "header-custom.less";
 @import "note-custom.less";
 @import "nc-homepage-custom.less";
+@import "nc-homepage-media-queries-custom.less";

--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -1,3 +1,9 @@
+/*
+ Notice & Comment Homepage styles
+ ==========================================================================
+ nc-homepage-custom.less styles for landing page
+ */
+
 .nc-homepage-header {
   .main-head {
     .font-regular;
@@ -230,7 +236,6 @@ Read and write with ease
       }
 
       .collapsible {
-
         .font-regular;
         margin: 25px 15px;
 
@@ -385,121 +390,3 @@ Footer partnership logos
   }
 }
 
-
-// tablet + mobile
-@media only screen and ( max-width: 780px ) {
-
-  .nc-homepage {
-    .hero-content {
-      padding: 0 20px;
-    }
-
-    section {
-      padding: 20px;
-    }
-  }
-}
-
-@media only screen and ( max-width: 480px ) {
-
-  .nc-homepage {
-
-    h2 {
-      font-size: 30px;
-      line-height: 35px;
-    }
-
-    .hero {
-      background-size: cover;
-      padding-top: 0;
-      text-align: center;
-    }
-
-    .hero-content {
-      padding: 20px;
-
-      h3 {
-        font-size: 23px;
-        margin: 0 0 15px 0;
-      }
-    }
-
-    .proposed-rule {
-      padding: 10px;
-
-      .comments-date {
-        .due,
-        .date {
-          float: none;
-        }
-      }
-    }
-
-    .read-proposed-rule {
-      padding: 7px;
-    }
-
-    .call-out {
-      margin: 0;
-    }
-
-    .call-out-content {
-      font-size: 25px;
-      line-height: 30px;
-      padding: 0 15px;
-    }
-
-    .read-and-write {
-      text-align: center;
-
-      ul {
-        margin: 20px 0;
-
-        li {
-          margin: 25px;
-        }
-
-        .image {
-          width: auto;
-        }
-
-        .content {
-          margin: 0;
-        }
-      }
-    }
-
-    .good-comment {
-      margin: 0;
-      padding: 20px;
-
-      h2 {
-        margin-bottom: 0;
-        text-align: center;
-      }
-
-      li span {
-        margin-left: 40px;
-      }
-    }
-
-    .about-this-tool {
-      padding: 20px;
-      text-align: center;
-
-      .about-this-tool-content {
-        display: block;
-      }
-
-      .about-this-tool-info {
-        padding-left: 0;
-      }
-    }
-
-    .footer {
-      display: block;
-      text-align: center;
-      padding: 10px;
-    }
-  }
-}

--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-media-queries-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-media-queries-custom.less
@@ -1,0 +1,167 @@
+/*
+ Notice & Comment Homepage Media Queries
+ ==========================================================================
+ nc-homepage-media-queries-custom.less
+ styles for tablet and mobile view of landing page
+ */
+
+// tablet + mobile
+@media only screen and ( max-width: 780px ) {
+
+  .nc-homepage {
+
+    .hero-content {
+      padding: 0 30px;
+    }
+
+    section {
+      padding: 20px 30px;
+    }
+  }
+}
+
+@media only screen and ( max-width: 480px ) {
+
+  .nc-homepage {
+    h1 {
+      font-size: 32px;
+      line-height: 36px;
+    }
+
+    h2 {
+      font-size: 24px;
+      line-height: 29px;
+    }
+
+    .hero {
+      background-size: cover;
+      padding-top: 0;
+    }
+
+    .hero-content {
+      padding: 30px 20px;
+
+      h3 {
+        font-size: 23px;
+        margin: 0 0 15px 0;
+      }
+    }
+
+    .proposed-rule {
+      padding: 10px;
+
+      .comments-date {
+        padding-top: 5px;
+
+        .due,
+        .date {
+          float: none;
+        }
+      }
+
+      .proposed-rule-title {
+        font-size: 19px;
+        margin-bottom: 20px;
+      }
+    }
+
+    .read-proposed-rule {
+      padding: 7px;
+    }
+
+    .call-out {
+      margin: 0;
+    }
+
+    .call-out-content {
+      font-size: 25px;
+      line-height: 30px;
+      padding: 0 15px;
+    }
+
+    section {
+      padding: 20px;
+    }
+
+    .read-and-write {
+      text-align: center;
+
+      ul {
+        margin: 20px 0;
+
+        li {
+          margin: 25px;
+        }
+
+        .image {
+          margin: 30px 0;
+          width: auto;
+        }
+
+        .content {
+          margin: 0;
+        }
+      }
+
+      .other-ways {
+        margin-bottom: 40px;
+        text-align: left;
+      }
+    }
+
+    .good-comment {
+      margin: 0;
+      padding: 20px 20px 35px 20px;
+
+      h2 {
+        margin-bottom: 30px;
+        text-align: center;
+      }
+
+      li  {
+        .triangle {
+          top: 5px;
+        }
+
+        .triangle,
+        .triangle:before,
+        .triangle:after {
+          height: 10px;
+          width:  10px;
+        }
+
+        span {
+          margin-left: 40px;
+        }
+      }
+    }
+
+    .about-this-tool {
+      padding: 20px 20px 60px 20px;
+      text-align: center;
+
+      .about-this-tool-content {
+        display: block;
+      }
+
+      .about-this-tool-info {
+        padding-left: 0;
+      }
+    }
+
+    .footer {
+      display: block;
+      text-align: center;
+      padding: 20px 10px 10px 10px;
+
+      span {
+        line-height: 6.5em;
+        vertical-align: top;
+      }
+
+      .logo {
+        margin-top: 22px;
+      }
+    }
+  }
+}

--- a/notice_and_comment/templates/regulations/nc-homepage.html
+++ b/notice_and_comment/templates/regulations/nc-homepage.html
@@ -47,11 +47,12 @@
               {{meta.title}}
             </div>
 
-            <div class="read-proposed-rule">
-                <a href="/preamble/{{ meta.document_number|dash_to_underscore }}">Read the proposed rule and write a comment <span class="fa fa-chevron-right" aria-hidden="true"></span></a>
-            </div>
-
           </div>
+
+          <div class="read-proposed-rule">
+            <a href="/preamble/{{ meta.document_number|dash_to_underscore }}">Read the proposed rule and write a comment <span class="fa fa-chevron-right" aria-hidden="true"></span></a>
+          </div>
+
           {% endfor %}
         </div>
 


### PR DESCRIPTION
Updated Homepage media queries for tablet/mobile view. #356 

**Tablet**
- 30px wide padding

<img width="779" alt="screen shot 2016-06-09 at 12 27 29 am" src="https://cloud.githubusercontent.com/assets/24054/15921950/09593be0-2dda-11e6-98d4-d9003d5c0010.png">

**Mobile**
- set header text sizes

<img width="322" alt="screen shot 2016-06-09 at 12 28 40 am" src="https://cloud.githubusercontent.com/assets/24054/15921957/1497dd40-2dda-11e6-917a-84f229da32f7.png">

_Hero_
- top 30px padding
- left align text
- even out margins
- rule title 19px

<img width="320" alt="screen shot 2016-06-09 at 12 28 50 am" src="https://cloud.githubusercontent.com/assets/24054/15921955/14975d20-2dda-11e6-98d8-34e870d6f734.png">

_Read and Write_
- image margins
- other ways to comment text left aligned
- section bottom padding

<img width="320" alt="screen shot 2016-06-09 at 12 28 59 am" src="https://cloud.githubusercontent.com/assets/24054/15921954/1497055a-2dda-11e6-8b33-7c7f95a589be.png">

_Build a good comment_
- smaller orange bullets
- section paddings

<img width="321" alt="screen shot 2016-06-09 at 12 29 14 am" src="https://cloud.githubusercontent.com/assets/24054/15921953/14969ade-2dda-11e6-9b2e-d6dfa6a9badc.png">

_About this tool_
- bottom padding

<img width="322" alt="screen shot 2016-06-09 at 12 29 23 am" src="https://cloud.githubusercontent.com/assets/24054/15921956/149743b2-2dda-11e6-9ac9-5860a2dea53c.png">

_Footer_
- align padding around text/logos

<img width="322" alt="screen shot 2016-06-09 at 12 29 41 am" src="https://cloud.githubusercontent.com/assets/24054/15921958/1497ebc8-2dda-11e6-82ea-918a15d0104f.png">