### PR TITLE
Tweak landing page for different notice states

### DIFF
--- a/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
+++ b/notice_and_comment/static/regulations/css/less/module/nc-homepage-custom.less
@@ -69,6 +69,7 @@
 Proposed Rule Box
 ================
 */
+  @proposed_rule_padding: 25px;
   .proposed-rule {
     background-color: @white;
     border-left: 1px solid @gray;
@@ -76,7 +77,7 @@ Proposed Rule Box
     border-top: 1px solid @gray;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
-    padding: 25px;
+    padding: @proposed_rule_padding;
 
     .comments-date {
       border-bottom: 1px solid @aqua_blue_2;
@@ -91,6 +92,11 @@ Proposed Rule Box
       .date {
         font-size: 15px;
         float: right;
+
+        .fa {
+          color: @uswds_dark_red;
+          padding-right: 5px;
+        }
       }
     }
 
@@ -132,6 +138,30 @@ Proposed Rule Box
       display: block;
       height: inherit;
       width: inherit;
+    }
+  }
+
+  .read-closed-proposed-rule {
+    background-color: @light_gray;
+    color: @black;
+    border-bottom-left-radius: 2px;
+    border-bottom-right-radius: 2px;
+    font-size: 17px;
+    padding: 10px @proposed_rule_padding;
+
+    strong {
+      float: left;
+    }
+
+    .fa {
+      padding-left: 5px;
+      vertical-align: middle;
+    }
+
+    a {
+      color: @blue;
+      text-align: right;
+      display: block;
     }
   }
 

--- a/notice_and_comment/templates/regulations/nc-homepage.html
+++ b/notice_and_comment/templates/regulations/nc-homepage.html
@@ -29,12 +29,14 @@
             <div class="comments-date group">
 
                 {% if meta.comment_state.value == comment_state.PREPUB %}
-                  <div class="date">Comment period is not open. The comment period will open once the rule is officially published in the Federal Register.</div>
+                  <div class="due">Comment period not yet open.</div>
+                  <div class="date">Rule not yet published.</div>
                 {% elif meta.comment_state.value == comment_state.OPEN %}
                   <div class="due">Comments are due in <strong>{{meta.days_remaining}} days!</strong></div>
-                  <div class="date">Ends {{meta.comments_close|date:"F d, Y"}}.</div>
+                  <div class="date">Ends {{meta.comments_close|date:"F d, Y"}} at 11:59pm.</div>
                 {% elif meta.comment_state.value == comment_state.CLOSED %}
-                  <div class="date">As of {{meta.comments_close|date:"F d, Y"}}, we are no longer accepting comments on this rule.</div>
+                  <div class="due">Comments are due in <strong>0 days!</strong></div>
+                  <div class="date"><span class="fa fa-exclamation-triangle"></span> Ended {{meta.comments_close|date:"F d, Y"}} at 11:59pm.</div>
                 {% endif %}
 
             </div>
@@ -49,10 +51,25 @@
 
           </div>
 
-          <div class="read-proposed-rule">
-            <a href="/preamble/{{ meta.document_number|dash_to_underscore }}">Read the proposed rule and write a comment <span class="fa fa-chevron-right" aria-hidden="true"></span></a>
-          </div>
-
+          {% if meta.comment_state.value == comment_state.CLOSED %}
+            <div class="read-closed-proposed-rule">
+              <strong>The comment period is closed.</strong>
+              <a href="{% url 'chrome_preamble' meta.document_number|dash_to_underscore %}">
+                Read the proposed rule
+                <span class="fa fa-chevron-right" aria-hidden="true"></span>
+              </a>
+            </div>
+          {% else %}
+            <div class="read-proposed-rule">
+              <a href="{% url 'chrome_preamble' meta.document_number|dash_to_underscore %}">
+                Read the proposed rule
+                {% if meta.comment_state.value == comment_state.OPEN %}
+                  and write a comment
+                {% endif %}
+                <span class="fa fa-chevron-right" aria-hidden="true"></span>
+              </a>
+            </div>
+          {% endif %}
           {% endfor %}
         </div>
 


### PR DESCRIPTION
In particular, text and icon changes for pre-publish and closed states

For #334 and #183

Looks like:

<img width="882" alt="screen shot 2016-06-09 at 3 07 42 pm" src="https://cloud.githubusercontent.com/assets/326918/15943567/a49b4e0e-2e57-11e6-8def-bdb4867d2543.png">
<img width="869" alt="screen shot 2016-06-09 at 2 00 33 pm" src="https://cloud.githubusercontent.com/assets/326918/15943569/a49f6f52-2e57-11e6-8dc9-9d0f04b0eb27.png">
<img width="894" alt="screen shot 2016-06-09 at 1 59 32 pm" src="https://cloud.githubusercontent.com/assets/326918/15943568/a49f2010-2e57-11e6-9def-0b6beb4aaa20.png">
