### PR TITLE
Color contrast updates

### DIFF
--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -1,19 +1,3 @@
-.activate-write {
-  color: @link_blue_inactive;
-
-  &:hover {
-    color: @link_blue;
-  }
-}
-
-.activate-read {
-  background: @blue;
-  color: @white;
-
-  &:hover {
-    background-color: darken(@blue, 10%);
-  }
-}
 
 .comment-button,
 a.comment-index-review {
@@ -71,6 +55,11 @@ a.comment-index-review {
 }
 
 #preamble-read {
+
+  .activate-write a {
+    color: @write_link_inactive;
+  }
+
   .cfr-instructions {
     font-family: "Merriweather", Georgia, serif;
     font-weight: 400;
@@ -94,6 +83,7 @@ a.comment-index-review {
 
     a.comment-context-toggle {
       .comment-context-text {
+        background-color: @light_gray;
         color: @link_blue;
       }
     }

--- a/notice_and_comment/static/regulations/css/less/comment-custom.less
+++ b/notice_and_comment/static/regulations/css/less/comment-custom.less
@@ -82,8 +82,9 @@ a.comment-index-review {
     }
 
     a.comment-context-toggle {
+      background-color: @light_gray;
+
       .comment-context-text {
-        background-color: @light_gray;
         color: @link_blue;
       }
     }

--- a/notice_and_comment/static/regulations/css/less/variables.less
+++ b/notice_and_comment/static/regulations/css/less/variables.less
@@ -19,6 +19,7 @@ variables.less contains all theme variable / variable overrides
 
 @link_blue: #0071BC;
 @link_blue_inactive: #9BDAF1;
+@write_link_inactive: #457D9A;
 
 @gray_blue: #5B616B;
 @navigation_gray: #676767;


### PR DESCRIPTION
- Darker "Write comment" colors for accessible contrast ratio.
- Lighter gray on Write mode excerpt toggle bar.

_also removed some unused styles_

#377 

<img width="945" alt="screen shot 2016-06-13 at 10 52 32 am" src="https://cloud.githubusercontent.com/assets/24054/16017489/057262b2-3155-11e6-8de1-8b092dd21991.png">

---

<img width="622" alt="screen shot 2016-06-13 at 11 07 19 am" src="https://cloud.githubusercontent.com/assets/24054/16018101/c5f144c0-3157-11e6-9af1-87d1e850acf5.png">

