### PR TITLE
Allow whole-site auth to be configured via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,11 +303,18 @@ what you have locally and regardless of what you’ve built the front-end
 against. Be sure to always update your local libraries (via pip) before
 building and pushing.
 
+### Read Authentication
+
+The environment variable, `WHOLE_SITE_AUTH`, will throw up a BASIC auth wall
+across the _entire_ site using Django middleware. For simplicity, this will
+reuse the existing `HTTP_AUTH_USER` and `HTTP_AUTH_PASSWORD` used by the write
+API.
+
 ### Non-Cloud.gov
 TODO; see `manifest` files, the cloud.gov documentation and
 https://atf-eregs.readthedocs.io/en/latest/production_setup.html#non-cloud-gov
 
-### Visual regression tests
+## Visual regression tests
 Visual regression tests can be run via BackstopJS.
 If not already installed, install BackstopJS via npm:
 ```

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -4,3 +4,4 @@ host: eregsnc-demo
 env:
   DOCUMENT_ID: EPA-HQ-OA-2016-0002-0001
   NEW_RELIC_APP_NAME: notice-comment-dev
+  WHOLE_SITE_AUTH: true

--- a/notice_and_comment/settings/base.py
+++ b/notice_and_comment/settings/base.py
@@ -156,5 +156,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
-    'notice_and_comment.basic_auth.BasicAuthMiddleware'
 )
+
+if os.getenv('WHOLE_SITE_AUTH'):
+    MIDDLEWARE_CLASSES += (
+        'notice_and_comment.basic_auth.BasicAuthMiddleware',
+    )


### PR DESCRIPTION
We want to drop auth on our sites, but may want to turn it on selectively in
the future.