### PR TITLE
Disable robots on demo

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -4,3 +4,4 @@ host: eregsnc-demo
 env:
   DOCUMENT_ID: EPA-HQ-OA-2016-0002-0001
   NEW_RELIC_APP_NAME: notice-comment-dev
+  DISABLE_ROBOTS: true


### PR DESCRIPTION
We don't want the demo site indexable. We don't _currently_ want prod
indexable, so its manifest isn't being updated.